### PR TITLE
Docs: Fix incorect name of VRT XML element (#2327)

### DIFF
--- a/gdal/doc/source/drivers/vector/vrt.rst
+++ b/gdal/doc/source/drivers/vector/vrt.rst
@@ -374,7 +374,7 @@ definitions:
    <OGRVRTDataSource>
        <OGRVRTLayer name="remapped_layer">
            <SrcDataSource>your_source.shp</SrcDataSource>
-           <SrcLayer>your_source</SrcSQL>
+           <SrcLayer>your_source</SrcLayer>
            <Field name="name" src="src_field_1" />
            <Field name="desc" src="src_field_2" type="String" width="45" />
        </OGRVRTLayer>


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
